### PR TITLE
Fix tests and deprecation warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.3-
+Compat

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -127,7 +127,7 @@ end
 function transform(g::GroupedDataFrame; kwargs...)
     result = DataFrame(g)
     idx2 = cumsum(Int[size(g[i],1) for i in 1:length(g)])
-    idx1 = [1, 1 + idx2[1:end-1]]
+    idx1 = [1; 1 + idx2[1:end-1]]
     for (k, v) in kwargs
         first = v(g[1])
         result[k] = Array(eltype(first), size(result, 1))
@@ -220,7 +220,7 @@ end
 ##
 ##############################################################################
 
-combnranges(starts, ends) = [[starts[i]:ends[i] for i in 1:length(starts)]...]
+combnranges(starts, ends) = [[starts[i]:ends[i] for i in 1:length(starts)]...;]
 
 DataFrame(g::GroupedDataFrame) = g.parent[g.idx[combnranges(g.starts, g.ends)], :]
 

--- a/src/compositedataframe.jl
+++ b/src/compositedataframe.jl
@@ -1,3 +1,4 @@
+using Compat
 
 export AbstractCompositeDataFrame, CompositeDataFrame
 
@@ -34,7 +35,7 @@ DataFrames.DataFrame(cdf::AbstractCompositeDataFrame) = DataFrame(values(cdf), n
 ## basic stuff
 #########################################
 
-Base.names{T <: AbstractCompositeDataFrame}(cdf::T) = collect(T.names)
+Base.names{T <: AbstractCompositeDataFrame}(cdf::T) = @compat fieldnames(T)
 
 DataFrames.ncol(cdf::AbstractCompositeDataFrame) = length(names(cdf))
 DataFrames.nrow(cdf::AbstractCompositeDataFrame) = ncol(cdf) > 0 ? length(cdf.(1))::Int : 0
@@ -42,7 +43,7 @@ DataFrames.nrow(cdf::AbstractCompositeDataFrame) = ncol(cdf) > 0 ? length(cdf.(1
 Base.values(cdf::AbstractCompositeDataFrame) = Any[ cdf.(i) for i in 1:length(cdf) ]
                 
 function Base.hcat(df1::AbstractCompositeDataFrame, df2::AbstractCompositeDataFrame)
-    nms = DataFrames.make_unique([names(df1), names(df2)])
+    nms = DataFrames.make_unique([names(df1); names(df2)])
     columns = Any[values(df1)..., values(df2)...]
     return CompositeDataFrame(columns, nms)
 end

--- a/test/chaining.jl
+++ b/test/chaining.jl
@@ -49,18 +49,15 @@ thread_left(x) = thread_left(filter(x-> !isa(x,Expr) || x.head != :line, x.args)
 
 function thread_left(x, expr, exprs...)
   if typeof(expr) == Symbol
-    call = Expr(:call, expr, x)
-
+    callexpr = Expr(:call, expr, x)
   elseif typeof(expr) == Expr && expr.head in [:call, :macrocall]
-    call = Expr(expr.head, expr.args[1], x, expr.args[2:end]...)
-
+    callexpr = Expr(expr.head, expr.args[1], x, expr.args[2:end]...)
   elseif typeof(expr) == Expr && expr.head == :->
-    call = Expr(:call, expr, x)
-
+    callexpr = Expr(:call, expr, x)
   else
     error("Unsupported expression $expr in @>")
   end
-  isempty(exprs) ? call : :(@> $call $(exprs...))
+  isempty(exprs) ? callexpr : :(@> $callexpr $(exprs...))
 end
 
 macro >(exprs...)

--- a/test/compositedataframes.jl
+++ b/test/compositedataframes.jl
@@ -5,13 +5,13 @@ using Base.Test
 using DataArrays, DataFrames
 using DataFramesMeta
 
-df = CompositeDataFrame(A = [1:3], B = [2, 1, 2])
+df = CompositeDataFrame(A = [1, 2, 3], B = [2, 1, 2])
 x = [2, 1, 0]
 
 @test  df.A == df[:A]
 @test  size(df[1:2,:]) == (2,2)
-@test  size(df[[1:2],:]) == (2,2)
-@test  size(df[[1:2], [:A]]) == (2,1)
+@test  size(df[[1, 2],:]) == (2,2)
+@test  size(df[[1, 2], [:A]]) == (2,1)
 @test  size(df[:, [:A]]) == (3,1)
 @test  size(df[:, 1:2]) == (3,2)
 @test  size(df[:, [1]]) == (3,1)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -2,14 +2,16 @@ module TestDicts
 
 using Base.Test
 using DataFramesMeta
+using Compat
+
 y = 3
-d = {:s => 3, :y => 44, :d => 5, :e => :(a + b)}
+@compat d = Dict(:s => 3, :y => 44, :d => 5, :e => :(a + b))
 @test @with(d, :s + :y) == d[:s] + d[:y]
 @test @with(d, :s + y)  == d[:s] + y
 @test @with(d, d)  == d
 @test @with(d, :s + d[^(:y)])  == d[:s] + d[:y]
 @test @with(d, :e.head) == d[:e].head
-@test @with({:s => 3, :y => 44, :d => 5, :e => :(a + b)}, :e.head) == d[:e].head
+@test @compat @with(Dict(:s => 3, :y => 44, :d => 5, :e => :(a + b)), :e.head) == d[:e].head
 
 x = @with d begin
     z = y + :y - 1

--- a/test/speedtests.jl
+++ b/test/speedtests.jl
@@ -12,7 +12,7 @@ b = rand(n)
 da = data(a)
 db = data(b)
 df = DataFrame(a = da, b = db)
-df2 = DataFrame({a, b})
+df2 = DataFrame(Any[a, b])
 names!(df2, [:a, :b])
 
 Base.values(da::DataArray) = da.data


### PR DESCRIPTION
Using 'call' as a variable name currently triggers a bug in
Julia 0.4: https://github.com/JuliaLang/julia/issues/11295
Work around it for now by using a different name.

Also get rid of deprecation warnings printed during the tests.


This PR currently breaks compatibility with 0.3. Should I use Compat.jl, or do you prefer creating a new branch for 0.4?