### PR TITLE
Add `@byrow`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ transform(df, newCol = cos(df[:x]), anotherCol = df[:x]^2 + 3*df[:x] + 4)
 
 `@transform` works for associative types, too.
 
+## `@byrow`
+
+Act on a DataFrame row-by-row. Includes support for control flow and `begin end` blocks. Since the "environment" induced by `@byrow df` is implicitly a single row of `df`, one uses regular operators and comparisons instead of their elementwise counterparts as in `@with`.
+
+```julia
+@byrow df if :A > :B; :A = :B * :C end
+```
+```julia
+function f()
+    x = 0.0
+    @byrow df begin
+        if :A < :B
+            x += :B * :C
+        end
+    end
+    x
+end
+```
+
 
 ## LINQ-Style Queries and Transforms
 

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -6,10 +6,12 @@ using DataFrames
 
 # Basics:
 export @with, @ix, @where, @orderby, @transform, @by, @based_on, @select
-export where, orderby, transform, select 
+export where, orderby, transform, select
 
 include("compositedataframe.jl")
 include("linqmacro.jl")
+include("byrow.jl")
+
 
 ##############################################################################
 ##
@@ -186,7 +188,7 @@ end
 
 expandargs(x) = x
 
-function expandargs(e::Expr) 
+function expandargs(e::Expr)
     if e.head == :quote && length(e.args) == 1
         return Expr(:kw, e.args[1], Expr(:quote, e.args[1]))
     else

--- a/src/byrow.jl
+++ b/src/byrow.jl
@@ -1,0 +1,37 @@
+
+export @byrow
+
+##############################################################################
+##
+## @byrow
+##
+##############################################################################
+
+# Recursive function that traverses the syntax tree of e, replaces instances of
+# ":(:(x))" with ":x[row]".
+function byrow_replace(e::Expr)
+    # target is the Expr that is built to replace ":(:(x))"
+    target = Expr(:ref)
+
+    # Traverse the syntax tree of e
+    if e.head != :quote
+        return Expr(e.head, (isempty(e.args) ? e.args : map(x -> byrow_replace(x), e.args))...)
+    else
+        push!(target.args, e, :row)
+        return target
+    end
+end
+
+# Set the base case for helper, i.e. for when expand hits an object of type
+# other than Expr (generally a Symbol or a literal).
+byrow_replace(x) = x
+
+function byrow_helper(df, body)
+    e_delimiters = Expr(:(=), :row, :( 1:length($df[1]) ))
+    e_forloop = Expr(:for, e_delimiters, byrow_replace(body))
+    return Expr(:macrocall, symbol("@with"), df, e_forloop)
+end
+
+macro byrow(df, body)
+    esc(byrow_helper(df, body))
+end

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -21,18 +21,30 @@ end
 @test  x == sum(df[:A] .* df[:B])
 @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df[:A] .> 1, [:B, :A]]
 @test  @with(df, DataFrame(a = :A * 2, b = :A + :B)) == DataFrame(a = df[:A] * 2, b = df[:A] + df[:B])
-    
+
 @test  @ix(df, :A .> 1)           == df[df[:A] .> 1,:]
-@test  @ix(df, :B .> 1)           == df[df[:B] .> 1,:]  
+@test  @ix(df, :B .> 1)           == df[df[:B] .> 1,:]
 @test  @ix(df, :A .> x)           == df[df[:A] .> x,:]
 @test  @ix(df, :B .> x)           == df[df[:B] .> x,:]
 @test  @ix(df, :A .> :B)          == df[df[:A] .> df[:B],:]
 @test  @ix(df, :A .> 1, [:B, :A]) == df[df[:A] .> 1, [:B, :A]]
 
 @test  @where(df, :A .> 1)         == df[df[:A] .> 1,:]
-@test  @where(df, :B .> 1)         == df[df[:B] .> 1,:]  
+@test  @where(df, :B .> 1)         == df[df[:B] .> 1,:]
 @test  @where(df, :A .> x)         == df[df[:A] .> x,:]
 @test  @where(df, :B .> x)         == df[df[:B] .> x,:]
 @test  @where(df, :A .> :B)        == df[df[:A] .> df[:B],:]
+
+@byrow(df, if :A > :B; :A = 0 end)
+@test  df == DataFrame(A = [1, 0, 0], B = [2, 1, 2])
+
+df = DataFrame(A = 1:3, B = [2, 1, 2])  # Restore df
+y = 0
+function f(x)
+    @byrow(df, if :A + :B == 3; x += 1 end)
+    x
+end
+y = f(y)
+@test  y == 2
 
 end # module


### PR DESCRIPTION
This PR includes `@byrow`, a macro for working with DataFrame objects row-by-row. Includes `/src/byrow.jl`, an addition to `test/dataframes.jl` and an addition to `README.md`.   