### PR TITLE
Add notation to support column references with a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ when used in the REPL than when used inside a function.
 
 `@with` allows DataFrame columns to be referenced as symbols like
 `:colX` in expressions. If an expression is wrapped in `^(expr)`,
-`expr` gets passed through untouched. Here are some examples:
+`expr` gets passed through untouched. If an expression is wrapped in 
+`_I_(expr)`, the column is referenced by the variable `expr` rather than
+a symbol. Here are some examples:
 
 ```julia
 using DataArrays, DataFrames
@@ -40,6 +42,9 @@ x = @with df begin
 end
 
 @with(df, df[:x .> 1, ^(:y)]) # The ^ means leave the :y alone
+
+colref = :x
+@with(df, :y + _I_(colref)) # Equivalent to df[:y] + df[colref]
 
 ```
 
@@ -313,4 +318,3 @@ end
 
 For performance, we should check to see if this can play nicely with
 `@devectorize` for use on columns.
-

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -18,6 +18,11 @@ x = @with df begin
     end
     res
 end
+idx = :A
+@test  @with(df, _I_(idx) + :B)  ==  df[:A] + df[:B]
+idx2 = :B
+@test  @with(df, _I_(idx) + _I_(idx2))  ==  df[:A] + df[:B]
+
 @test  x == sum(df[:A] .* df[:B])
 @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df[:A] .> 1, [:B, :A]]
 @test  @with(df, DataFrame(a = :A * 2, b = :A + :B)) == DataFrame(a = df[:A] * 2, b = df[:A] + df[:B])


### PR DESCRIPTION
Adds a feature to support column references as a variable. `@with(d, _I_(colref))` is the same as `d[colref]` (no colons there).

This is for #23. 

* Note that `@byrow!` doesn't support this feature. (There's no reason it couldn't be added.) It should work with the other macros like `@where`.

* The syntax is a little verbose. There might be punctuation available for this. Another option would be to embed the indicator in a symbol name. For example, `@with(d, :_I_colref)` is the same as `d[colref]`.

