### PR TITLE
 	Add PassThrough type to make it easier to use Arrays and NullableArrays

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -515,4 +515,22 @@ Base.getindex(gd::GroupedDataFrame, I::AbstractArray{Int}) = GroupedDataFrame(gd
                                                                               gd.starts[I],
                                                                               gd.ends[I])
 
+
+##############################################################################
+##
+## Extras for easier handling of Arrays
+##
+##############################################################################
+
+export P, PassThrough
+
+type PassThrough{T} <: AbstractVector{T}
+    x::AbstractVector{T}
+end
+const P = PassThrough
+size(x::PassThrough) = size(x.x)
+getindex(x::PassThrough, i) = getindex(x.x, i)
+
+DataFrames.upgrade_vector(v::PassThrough) = v.x
+
 end # module

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -528,6 +528,7 @@ type PassThrough{T} <: AbstractVector{T}
     x::AbstractVector{T}
 end
 const P = PassThrough
+
 size(x::PassThrough) = size(x.x)
 getindex(x::PassThrough, i) = getindex(x.x, i)
 


### PR DESCRIPTION
It's undocumented (for now). Here's an example:

```julia
julia> d = DataFrame(a = P(rand(10)), b = P(1:10))
10x2 DataFrames.DataFrame
| Row | a         | b  |
|-----|-----------|----|
| 1   | 0.0775549 | 1  |
| 2   | 0.494738  | 2  |
| 3   | 0.0811539 | 3  |
| 4   | 0.508829  | 4  |
| 5   | 0.791939  | 5  |
| 6   | 0.775498  | 6  |
| 7   | 0.227743  | 7  |
| 8   | 0.612652  | 8  |
| 9   | 0.111757  | 9  |
| 10  | 0.550457  | 10 |

julia> dump(d)
DataFrames.DataFrame  10 observations of 2 variables
  a: Array(Float64,(10,)) [0.07755486805429457,0.49473806399672116,0.0811539076123835,0.5088286373469713,0.7919390272672715,0.7754980486430811,0.22774251447406058,0.6126518937183227,0.11175723545500538,0.5504568184557108]
  b: UnitRange{Int64} 
    start: Int64 1
    stop: Int64 10


```