### PR TITLE
Add @newcol feature to @byrow!

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,27 @@ let x = 0.0
 end
 ```
 
+Note that the let block is required here to create a scope to allow assignment
+of `x` within `@byrow!`.
+
+`byrow!` also supports special syntax for allocating new columns to make
+`byrow!` more useful for data transformations. The syntax `@newcol
+x::Array{Int}` allocates a new column `:x` with an `Array` container with eltype
+`Int`. Note that the returned AbstractDataFrame includes these new columns, but
+the original `df` is not affected. Here is an example where two new columns are
+added:
+
+```julia
+df = DataFrame(A = 1:3, B = [2, 1, 2])
+df2 = @byrow! df begin
+    @newcol colX::Array{Float64}
+    @newcol colY::DataArray{Int}
+    :colX = :B == 2 ? pi * :A : :B
+    if :A > 1 
+        :colY = :A * :B
+    end
+end
+```
 
 ## LINQ-Style Queries and Transforms
 

--- a/src/byrow.jl
+++ b/src/byrow.jl
@@ -26,12 +26,37 @@ end
 # other than Expr (generally a Symbol or a literal).
 byrow_replace(x) = x
 
+function byrow_find_newcols(e::Expr, newcol_decl)
+    if e.head == :macrocall && e.args[1] == symbol("@newcol")
+        ea = e.args[2]
+        # expression to assign a new column to df
+        return (nothing, Any[Expr(:kw, ea.args[1], Expr(:call, ea.args[2].args[1], ea.args[2].args[2], :_N))])
+    else
+        if isempty(e.args)
+            return (e.args, Any[])
+        end
+        newargs = Any[]
+        for ea in e.args
+            (nea, newcol) = byrow_find_newcols(ea, newcol_decl)
+            nea != nothing && push!(newargs, nea) 
+            nea == nothing && length(newcol) > 0 && append!(newcol_decl, newcol) 
+        end
+        return (Expr(e.head, newargs...), newcol_decl)
+    end
+end
+
+byrow_find_newcols(x, newcol_decl) = (x, Any[])
+
 function byrow_helper(df, body)
-    e_delimiters = Expr(:(=), :row, :( 1:length($df[1]) ))
-    e_forloop = Expr(:for, e_delimiters, byrow_replace(body))
-    return Expr(:block,
-                Expr(:macrocall, symbol("@with"), df, e_forloop),
-                df)
+    (e_body, e_newcols) = byrow_find_newcols(body, Any[])
+    e_delimiters = Expr(:(=), :row, :( 1:_N ))
+    e_forloop = Expr(:for, e_delimiters, byrow_replace(e_body))
+    return quote
+        _N = length($df[1])
+        _DF = @transform($df, $(e_newcols...))
+        @with _DF $e_forloop
+        _DF
+    end
 end
 
 """
@@ -46,10 +71,20 @@ Includes support for control flow and `begin end` blocks. Since the
 use regular operators and comparisons instead of their elementwise counterparts
 as in `@with`. Note that the scope within `@byrow!` is a hard scope.
 
+`byrow!` also supports special syntax for allocating new columns. The syntax
+`@newcol x::Array{Int}` allocates a new column `:x` with an `Array` container
+with eltype `Int`. Note that the returned `AbstractDataFrame` includes these new
+columns, but the original `d` is not affected. This feature makes it easier to
+use `byrow!` for data transformations.
+
 ### Arguments
 
-* `d` : an AbstractDataFrame
+* `d` : an `AbstractDataFrame`
 * `expr` : expression operated on row by row
+
+### Returns
+
+The modified `AbstractDataFrame`.
 
 ### Examples
 
@@ -60,6 +95,10 @@ let x = 0
     x
 end
 @byrow! df if :A > :B; :A = 0 end
+df2 = @byrow! df begin
+    @newcol colX::Array{Float64}
+    :colX = :B == 2 ? pi * :A : :B
+end
 ```
 
 """

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -49,4 +49,16 @@ y = 0
 @byrow!(df, if :A + :B == 3; global y += 1 end)
 @test  y == 2
 
+df = DataFrame(A = 1:3, B = [2, 1, 2])
+df2 = @byrow! df begin
+    @newcol colX::Array{Float64}
+    @newcol colY::DataArray{Int}
+    :colX = :B == 2 ? pi * :A : :B
+    if :A > 1 
+        :colY = :A * :B
+    end
+end
+@test  df2[:colX] == [pi, 1.0, 3pi]
+@test  isna(df2[1, :colY])
+@test  df2[2, :colY] == 2
 end # module


### PR DESCRIPTION
See #42 for background. Some notes:

* New columns don't get added to the original DataFrame, only the result.

* The syntax is based on the suggestion by @nalimilan:

```julia
df = DataFrame(A = 1:3, B = [2, 1, 2])
df2 = @byrow! df begin
    @newcol colX::Array{Float64}
    @newcol colY::DataArray{Int}
    :colX = :B == 2 ? pi * :A : :B
    if :A > 1 
        :colY = :A * :B
    end
end
```