### PR TITLE
Improvements to CompositeDataFrames, including type-stable row access

### DIFF
--- a/test/cdftimings.jl
+++ b/test/cdftimings.jl
@@ -1,5 +1,5 @@
 
-module CompositeDataFramesTimings
+module CompositeDataFrameTimings
 
 using DataArrays, DataFrames
 using DataFramesMeta
@@ -8,7 +8,8 @@ srand(1)
 const n = 5_000_000
 a = rand(n)
 b = rand(n)
-cdf = CompositeDataFrame(a = a, b = b)
+c = rand(1:5, n)
+cdf = CompositeDataFrame(a = a, b = b, c = c)
 df = DataFrame(cdf)
 
 function dot1(df::AbstractDataFrame)
@@ -37,11 +38,40 @@ function dot3(df::AbstractDataFrame)
     end
 end
 
+function dot4(df::AbstractDataFrame)
+    x = 0.0
+    for r in eachrow(df)
+        x += r.a * r.b
+    end
+    return x
+end
+
+function dot5(df::AbstractDataFrame)
+    x = 0.0
+    for i in 1:nrow(df)
+        x += df.a[i] * df.b[i]
+    end
+    return x
+end
+
+function dot6(df::AbstractDataFrame)
+    x = 0.0
+    for i in 1:nrow(df)
+        r = row(df, i)
+        x += r.a * r.b
+    end
+    return x
+
+end
+
 @show t1 = @elapsed dot1(df)
 @show t2 = @elapsed dot2(df)
 @show t3 = @elapsed dot3(df)
 @show t1c = @elapsed dot1(cdf)
 @show t2c = @elapsed dot2(cdf)
 @show t3c = @elapsed dot3(cdf)
+@show t4c = @elapsed dot4(cdf)
+@show t5c = @elapsed dot5(cdf)
+@show t6c = @elapsed dot6(cdf)
 
 end # module

--- a/test/compositedataframes.jl
+++ b/test/compositedataframes.jl
@@ -45,4 +45,14 @@ df2 = @transform(df, C = :A + 1)
 df3 = @select(df, :B, C = :A + 1, :A)
 @test df3.C == df.A + 1
 
+df = CompositeDataFrame(:MyDF, A = [1, 2, 3], B = [2, 1, 2])
+@test typeof(df) == MyDF
+@test  df.A == df[:A]
+
+res = 0
+for x in eachrow(df)
+    res += x.A * x.B
+end
+@test res == sum(df.A .* df.B)
+
 end # module


### PR DESCRIPTION
Includes:

*  `row(d,i)` and `eachrow(d, i)` for type-stable row access
* Named composite type creation
* More documentation