### PR TITLE
Fix depwarn() usage

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -149,7 +149,7 @@ ix_helper(d, arg) = :( let d = $d; $d[DataFramesMeta.@with($d, $arg),:]; end )
 ix_helper(d, arg, moreargs...) = :( let d = $d; getindex(d, DataFramesMeta.@with(d, $arg), $(moreargs...)); end )
 
 macro ix(d, args...)
-    depwarn("`@ix` is deprecated; use `@where` and `@select`.")
+    Base.depwarn("`@ix` is deprecated; use `@where` and `@select`.", Symbol("@ix"))
     esc(ix_helper(d, args...))
 end
 

--- a/src/linqmacro.jl
+++ b/src/linqmacro.jl
@@ -95,7 +95,7 @@ function linq(::SymbolParameter{:with}, d, body)
 end
 
 function linq(::SymbolParameter{:ix}, d, args...)
-    depwarn("`ix` is deprecated; use `where` and `select`.")
+    Base.depwarn("`ix` is deprecated; use `where` and `select`.", :ix)
     ix_helper(d, args...)
 end
 


### PR DESCRIPTION
In Julia 0.4.5 `depwarn()` is not exported, the Base module should be explicitly specified.