### PR TITLE
Fixed `using DataFramesMeta: @where`

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -168,7 +168,7 @@ collect_ands(x::Expr) = x
 collect_ands(x::Expr, y::Expr) = :($x & $y)
 collect_ands(x::Expr, y...) = :($x & $(collect_ands(y...)))
 
-where_helper(d, args...) = :( DataFramesMeta.where($d, _DF -> DataFramesMeta.@with(_DF, $(collect_ands(args...)))) )
+where_helper(d, args...) = :( $DataFramesMeta.where($d, _DF -> $DataFramesMeta.@with(_DF, $(collect_ands(args...)))) )
 
 """
 ```julia

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -168,7 +168,7 @@ collect_ands(x::Expr) = x
 collect_ands(x::Expr, y::Expr) = :($x & $y)
 collect_ands(x::Expr, y...) = :($x & $(collect_ands(y...)))
 
-where_helper(d, args...) = :( where($d, _DF -> DataFramesMeta.@with(_DF, $(collect_ands(args...)))) )
+where_helper(d, args...) = :( DataFramesMeta.where($d, _DF -> DataFramesMeta.@with(_DF, $(collect_ands(args...)))) )
 
 """
 ```julia


### PR DESCRIPTION
Before, this yielded an error:

```julia
using DataFramesMeta: @where
using RDatasets: dataset

df = dataset("datasets", "iris")

@where df :Species .== "setosa"
```