### PR TITLE
fix some deprecation warnings and errors for 0.6

### DIFF
--- a/src/compositedataframe.jl
+++ b/src/compositedataframe.jl
@@ -9,9 +9,9 @@ export AbstractCompositeDataFrame, AbstractCompositeDataFrameRow,
 An abstract type that is an `AbstractDataFrame`. Each type that inherits from
 this is expected to be a type-stable data frame.
 """
-abstract AbstractCompositeDataFrame <: AbstractDataFrame
+@compat abstract type AbstractCompositeDataFrame <: AbstractDataFrame end
 
-abstract AbstractCompositeDataFrameRow
+@compat abstract type AbstractCompositeDataFrameRow end
 
 
 """

--- a/test/chaining.jl
+++ b/test/chaining.jl
@@ -17,13 +17,13 @@ x = @by(x, :b, meanX = mean(:x), meanY = mean(:y))
 x = @orderby(x, :b, -:meanX)
 x = @select(x, var = :b, :meanX, :meanY)
 
-x_as = @as _ begin
+x_as = @as X begin
     df
-    @where(_, :a .> 2)
-    @transform(_, y = 10 * :x)
-    @by(_, :b, meanX = mean(:x), meanY = mean(:y))
-    @orderby(_, :b, -:meanX)
-    @select(_, var = :b, :meanX, :meanY)
+    @where(X, :a .> 2)
+    @transform(X, y = 10 * :x)
+    @by(X, :b, meanX = mean(:x), meanY = mean(:y))
+    @orderby(X, :b, -:meanX)
+    @select(X, var = :b, :meanX, :meanY)
 end
 
 x_thread = @> begin

--- a/test/compositedataframes.jl
+++ b/test/compositedataframes.jl
@@ -1,6 +1,8 @@
 
 module TestCompositeDataFrames
 
+using Compat
+
 using Base.Test
 using DataArrays, DataFrames
 using DataFramesMeta
@@ -19,8 +21,8 @@ x = [2, 1, 0]
 @test  size([df df]) == (3,4)
 
 @test  @with(df, :A + 1)   ==  df[:A] + 1
-@test  @with(df, :A + :B)  ==  df[:A] + df[:B]
-@test  @with(df, :A + x)   ==  df[:A] + x
+@test  @with(df, :A .+ :B)  ==  df[:A] .+ df[:B]
+@test  @with(df, :A .+ x)   ==  df[:A] .+ x
 x = @with df begin
     res = 0.0
     for i in 1:length(:A)

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -1,5 +1,6 @@
-
 module TestDataFrames
+
+using Compat
 
 using Base.Test
 using DataArrays, DataFrames
@@ -8,9 +9,9 @@ using DataFramesMeta
 df = DataFrame(A = 1:3, B = [2, 1, 2])
 x = [2, 1, 0]
 
-@test  @with(df, :A + 1)   ==  df[:A] + 1
-@test  @with(df, :A + :B)  ==  df[:A] + df[:B]
-@test  @with(df, :A + x)   ==  df[:A] + x
+@test  @with(df, :A .+ 1)   ==  df[:A] .+ 1
+@test  @with(df, :A .+ :B)  ==  df[:A] .+ df[:B]
+@test  @with(df, :A .+ x)   ==  df[:A] .+ x
 x = @with df begin
     res = 0.0
     for i in 1:length(:A)
@@ -19,20 +20,20 @@ x = @with df begin
     res
 end
 idx = :A
-@test  @with(df, _I_(idx) + :B)  ==  df[:A] + df[:B]
+@test  @with(df, _I_(idx) .+ :B)  ==  df[:A] .+ df[:B]
 idx2 = :B
-@test  @with(df, _I_(idx) + _I_(idx2))  ==  df[:A] + df[:B]
+@test  @with(df, _I_(idx) .+ _I_(idx2))  ==  df[:A] .+ df[:B]
 
 @test  x == sum(df[:A] .* df[:B])
 @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df[:A] .> 1, [:B, :A]]
-@test  @with(df, DataFrame(a = :A * 2, b = :A + :B)) == DataFrame(a = df[:A] * 2, b = df[:A] + df[:B])
+@test  @with(df, DataFrame(a = :A * 2, b = :A .+ :B)) == DataFrame(a = df[:A] * 2, b = df[:A] .+ df[:B])
 
 @test  @where(df, :A .> 1)          == df[df[:A] .> 1,:]
 @test  @where(df, :B .> 1)          == df[df[:B] .> 1,:]
 @test  @where(df, :A .> x)          == df[df[:A] .> x,:]
 @test  @where(df, :B .> x)          == df[df[:B] .> x,:]
 @test  @where(df, :A .> :B)         == df[df[:A] .> df[:B],:]
-@test  @where(df, :A .> 1, :B .> 1) == df[(df[:A] .> 1) & (df[:B] .> 1),:]
+@test  @where(df, :A .> 1, :B .> 1) == df[(df[:A] .> 1) .& (df[:B] .> 1),:]
 
 @test @byrow!(df, if :A > :B; :A = 0 end) == DataFrame(A = [1, 0, 0], B = [2, 1, 2])
 @test  df == DataFrame(A = [1, 0, 0], B = [2, 1, 2])

--- a/test/linqmacro.jl
+++ b/test/linqmacro.jl
@@ -1,5 +1,7 @@
 module TestLinqMacro
 
+using Compat
+
 using Base.Test
 using DataArrays, DataFrames
 using DataFramesMeta


### PR DESCRIPTION
Replace `&` with `.&` and use updated syntax for `abstract types`