### PR TITLE
use more specific VERSION cutoff for .& call

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -194,7 +194,7 @@ where(d::AbstractDataFrame, arg) = d[arg, :]
 where(d::AbstractDataFrame, f::Function) = d[f(d), :]
 where(g::GroupedDataFrame, f::Function) = g[Bool[f(x) for x in g]]
 
-if VERSION < v"0.6.0-"
+if VERSION < v"0.6.0-dev.1632" # julia PR #17623
     and(x, y) = :($x & $y)
 else
     and(x, y) = :($x .& $y)


### PR DESCRIPTION
to avoid breaking the package on early 0.6-dev versions where `.&` did not work yet