### PR TITLE
fix depwarn in orderby

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -313,7 +313,7 @@ end
 orderby(d::AbstractDataFrame, f::Function) = d[sortperm(f(d)), :]
 orderby(g::GroupedDataFrame, f::Function) = g[sortperm([f(x) for x in g])]
 
-orderbyconstructor(d::AbstractDataFrame) = (x...) -> DataFrame(Any[x...])
+orderbyconstructor(d::AbstractDataFrame) = (x...) -> DataFrame(Any[x...], Symbol.(1:length(x)))
 orderbyconstructor(d) = x -> x
 
 function orderby_helper(d, args...)


### PR DESCRIPTION
A quickfix to reseolve #82. It calls an internal function of `DataFrames` for consistency but I assume we should allowed it here as it is a closely coupled package.
In general the reason for the problem was that we actually do not care about column names in this case.