### PR TITLE
various fixes for 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 DataFrames 0.11
+Compat 0.57.0

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -1,6 +1,6 @@
 module DataFramesMeta
 
-using DataFrames
+using DataFrames, Compat
 
 # Basics:
 export @with, @ix, @where, @orderby, @transform, @by, @based_on, @select
@@ -84,11 +84,11 @@ end
 """
     @with(d, expr)
 
-`@with` allows DataFrame columns or Associative keys to be referenced as symbols.
+`@with` allows DataFrame columns or AbstractDict keys to be referenced as symbols.
 
 ### Arguments
 
-* `d` : an AbstractDataFrame or Associative type
+* `d` : an AbstractDataFrame or AbstractDict type
 * `expr` : the expression to evaluate in `d`
 
 ### Details
@@ -382,7 +382,7 @@ end
 ##
 ##############################################################################
 
-function transform(d::Union{AbstractDataFrame, Associative}; kwargs...)
+function transform(d::Union{AbstractDataFrame, AbstractDict}; kwargs...)
     result = copy(d)
     for (k, v) in kwargs
         result[k] = isa(v, Function) ? v(d) : v
@@ -420,14 +420,14 @@ Add additional columns or keys based on keyword arguments.
 
 ### Arguments
 
-* `d` : an Associative type, AbstractDataFrame, or GroupedDataFrame
+* `d` : an AbstractDict type, AbstractDataFrame, or GroupedDataFrame
 * `i...` : keyword arguments defining new columns or keys
 
-For Associative types, `@transform` only works with keys that are symbols.
+For AbstractDict types, `@transform` only works with keys that are symbols.
 
 ### Returns
 
-* `::AbstractDataFrame`, `::Associative`, or `::GroupedDataFrame`
+* `::AbstractDataFrame`, `::AbstractDict`, or `::GroupedDataFrame`
 
 ### Examples
 
@@ -622,7 +622,7 @@ end
 ##
 ##############################################################################
 
-function Base.select(d::Union{AbstractDataFrame, Associative}; kwargs...)
+function Base.select(d::Union{AbstractDataFrame, AbstractDict}; kwargs...)
     result = typeof(d)()
     for (k, v) in kwargs
         result[k] = v
@@ -665,13 +665,13 @@ Select and transform columns.
 
 ### Arguments
 
-* `d` : an AbstractDataFrame or Associative
+* `d` : an AbstractDataFrame or AbstractDict
 * `e` :  keyword arguments specifying new columns in terms of existing columns
   or symbols to specify existing columns
 
 ### Returns
 
-* `::AbstractDataFrame` or `::Associative`
+* `::AbstractDataFrame` or `::AbstractDict`
 
 ### Examples
 

--- a/src/compositedataframe.jl
+++ b/src/compositedataframe.jl
@@ -170,7 +170,7 @@ This iterator is created by calling `eachrow(df)` where `df` is an
 
 See also `row(cdf, i)`.
 """
-immutable CDFRowIterator{T <: AbstractCompositeDataFrame}
+struct CDFRowIterator{T <: AbstractCompositeDataFrame}
     df::T
     len::Int
 end

--- a/src/compositedataframe.jl
+++ b/src/compositedataframe.jl
@@ -138,8 +138,7 @@ DataFrames.index(cdf::AbstractCompositeDataFrame) = DataFrames.Index(names(cdf))
 #########################################
 
 Base.getindex(cdf::AbstractCompositeDataFrame, col_inds::DataFrames.ColumnIndex) = getfield(cdf, col_inds)
-function Base.getindex(cdf::AbstractCompositeDataFrame, col_inds::AbstractVector{T}
-                      ) where {T<:DataFrames.ColumnIndex}
+function Base.getindex(cdf::AbstractCompositeDataFrame, col_inds::AbstractVector{T}) where {T<:DataFrames.ColumnIndex}
     CompositeDataFrame(Any[ getfield(cdf, col_inds[i]) for i = 1:length(col_inds) ], names(cdf)[col_inds])
 end
 Base.getindex(cdf::AbstractCompositeDataFrame, row_inds, col_inds::DataFrames.ColumnIndex) = getfield(cdf, col_inds)[row_inds]

--- a/src/linqmacro.jl
+++ b/src/linqmacro.jl
@@ -68,7 +68,7 @@ macro linq(arg)
 end
 
 # Snippet from Calculus.jl
-immutable SymbolParameter{T} end
+struct SymbolParameter{T} end
 SymbolParameter(s::Symbol) = SymbolParameter{s}()
 
 replacefuns(x) = x  # default for non-expression stuff
@@ -105,7 +105,7 @@ end
 ##############################################################################
 
 ## Default, no-op:
-linq{s}(::SymbolParameter{s}, args...) = Expr(:call, s, args...)
+linq(::SymbolParameter{s}, args...) where {s} = Expr(:call, s, args...)
 
 function linq(::SymbolParameter{:with}, d, body)
     with_helper(d, body)

--- a/test/cdftimings.jl
+++ b/test/cdftimings.jl
@@ -1,6 +1,7 @@
 
 module CompositeDataFrameTimings
 
+using Compat.Random
 using DataArrays, DataFrames
 using DataFramesMeta
 

--- a/test/chaining.jl
+++ b/test/chaining.jl
@@ -1,7 +1,7 @@
 module TestChaining
 
-using Base.Test
-using DataArrays, DataFrames
+using Compat.Test, Compat.Random
+using DataFrames
 using DataFramesMeta
 using Lazy
 

--- a/test/compositedataframes.jl
+++ b/test/compositedataframes.jl
@@ -1,8 +1,8 @@
 
 module TestCompositeDataFrames
 
-using Base.Test
-using DataArrays, DataFrames
+using Compat.Test
+using DataFrames
 using DataFramesMeta
 
 df = CompositeDataFrame(A = [1, 2, 3], B = [2, 1, 2])

--- a/test/data.table.timings.jl
+++ b/test/data.table.timings.jl
@@ -1,6 +1,7 @@
 # Julia benchmarks from R's data.table
 # https://github.com/Rdatatable/data.table/wiki/Benchmarks-:-Grouping
 
+using Compat.Random
 using DataFrames, DataFramesMeta
 using CategoricalArrays, DataArrays
 

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -1,17 +1,17 @@
 
 module TestDataFrames
 
-using Base.Test
-using DataArrays, DataFrames
+using Compat.Test
+using DataFrames
 using DataFramesMeta
 
 df = DataFrame(A = 1:3, B = [2, 1, 2])
 
 x = [2, 1, 0]
 
-@test  @with(df, :A + 1)   ==  df[:A] + 1
-@test  @with(df, :A + :B)  ==  df[:A] + df[:B]
-@test  @with(df, :A + x)   ==  df[:A] + x
+@test  @with(df, :A .+ 1)   ==  df[:A] + 1
+@test  @with(df, :A .+ :B)  ==  df[:A] + df[:B]
+@test  @with(df, :A .+ x)   ==  df[:A] + x
 
 x = @with df begin
     res = 0.0
@@ -21,13 +21,13 @@ x = @with df begin
     res
 end
 idx = :A
-@test  @with(df, _I_(idx) + :B)  ==  df[:A] + df[:B]
+@test  @with(df, _I_(idx) .+ :B)  ==  df[:A] .+ df[:B]
 idx2 = :B
-@test  @with(df, _I_(idx) + _I_(idx2))  ==  df[:A] + df[:B]
+@test  @with(df, _I_(idx) .+ _I_(idx2))  ==  df[:A] .+ df[:B]
 
 @test  x == sum(df[:A] .* df[:B])
 @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df[:A] .> 1, [:B, :A]]
-@test  @with(df, DataFrame(a = :A * 2, b = :A + :B)) == DataFrame(a = df[:A] * 2, b = df[:A] + df[:B])
+@test  @with(df, DataFrame(a = :A * 2, b = :A .+ :B)) == DataFrame(a = df[:A] * 2, b = df[:A] .+ df[:B])
 
 @test where(df, 1) == df[1, :]
 

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -9,9 +9,9 @@ df = DataFrame(A = 1:3, B = [2, 1, 2])
 
 x = [2, 1, 0]
 
-@test  @with(df, :A .+ 1)   ==  df[:A] + 1
-@test  @with(df, :A .+ :B)  ==  df[:A] + df[:B]
-@test  @with(df, :A .+ x)   ==  df[:A] + x
+@test  @with(df, :A .+ 1)   ==  df[:A] .+ 1
+@test  @with(df, :A .+ :B)  ==  df[:A] .+ df[:B]
+@test  @with(df, :A .+ x)   ==  df[:A] .+ x
 
 x = @with df begin
     res = 0.0

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1,6 +1,6 @@
 module TestDicts
 
-using Base.Test
+using Compat.Test
 using DataFramesMeta
 
 y = 3

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2,7 +2,7 @@
 
 module TestGrouping
 
-using Base.Test
+using Compat.Test
 using DataArrays, DataFrames
 using DataFramesMeta
 

--- a/test/linqmacro.jl
+++ b/test/linqmacro.jl
@@ -1,7 +1,7 @@
 module TestLinqMacro
 
-using Base.Test
-using DataArrays, DataFrames
+using Compat.Test
+using DataFrames
 using DataFramesMeta
 
 srand(100)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ for my_test in my_tests
         include(my_test)
         println("\t\033[1m\033[32mPASSED\033[0m: $(my_test)")
     catch
-        anyerrors = true
+        global anyerrors = true
         println("\t\033[1m\033[31mFAILED\033[0m: $(my_test)")
         if fatalerrors
             rethrow()

--- a/test/speedtests.jl
+++ b/test/speedtests.jl
@@ -1,6 +1,6 @@
 module SpeedTests
 
-using Base.Test
+using Compat.Test, Compat.Random
 using DataArrays, DataFrames
 using DataFramesMeta
 using Devectorize

--- a/test/timings.jl
+++ b/test/timings.jl
@@ -1,6 +1,7 @@
 
 module DataFramesTimings
 
+using Compat.Random
 using DataArrays, DataFrames
 using DataFramesMeta
 


### PR DESCRIPTION
These are a bunch of simple fixes for 0.7.  There are still some outstanding problems.  In particular, wrong variables seem to get substituted in some cases.  It's almost as if DataFramesMeta is depending on ordering of `Expr` args somewhere where it shouldn't be, but it wasn't easy to find the problem (and I didn't).  This is a good first step at least.