### PR TITLE
Fix incorrect ordering of columns with where and transform

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -69,9 +69,7 @@ function with_helper(d, body)
             function $funname($(values(membernames)...))
                 $body
             end
-            $funname($(map(keys(membernames)) do key
-                :($d[$key])
-            end...))
+            $funname($((:($d[$key]) for key in keys(membernames))...))
         end
     end
 end


### PR DESCRIPTION
Calling `map()` over `keys(membernames)` returns a `Set`, which loses the ordering of columns and can make it inconsistent with `values(membernames)`.

Fixes https://github.com/JuliaStats/DataFramesMeta.jl/issues/88.