### PR TITLE
Allow for scalars in a grouped @transform

### DIFF
--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -393,7 +393,8 @@ function transform(g::GroupedDataFrame; kwargs...)
     idx1 = [1; 1 + idx2[1:end-1]]
     for (k, v) in kwargs
         first = v(g[1])
-        result[k] = Array{eltype(first)}(size(result, 1))
+        first isa Vector ? (T = eltype(first)) : (T = typeof(first))
+        result[k] = Array{T}(size(result, 1))
         result[idx1[1]:idx2[1], k] = first
         for i in 2:length(g)
             result[idx1[i]:idx2[i], k] = v(g[i])


### PR DESCRIPTION
Resolves issue #98 with a one-liner. 

This way we can spread grouped vector-to-scalar operations across groups easily. This behavior is already feasible, but it threw an error with strings because `eltype(String)` is `Char`. Now it will allocate a vector of type `String`. 

Next step is  to automatically expand the type of the vector if a group is entirely missing. Note that this would have thrown an error before this PR as well. 