### PR TITLE
Rename _I_ to cols to be consistent with others

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ These macros improve performance and provide more convenient syntax.
 `@with` allows DataFrame columns to be referenced as symbols like
 `:colX` in expressions. If an expression is wrapped in `^(expr)`,
 `expr` gets passed through untouched. If an expression is wrapped in
-`_I_(expr)`, the column is referenced by the variable `expr` rather than
+`cols(expr)`, the column is referenced by the variable `expr` rather than
 a symbol. Here are some examples:
 
 ```julia
@@ -39,7 +39,7 @@ end
 @with(df, df[:x .> 1, ^(:y)]) # The ^ means leave the :y alone
 
 colref = :x
-@with(df, :y + _I_(colref)) # Equivalent to df[:y] + df[colref]
+@with(df, :y + cols(colref)) # Equivalent to df[:y] + df[colref]
 ```
 
 This works for `AbstractDict` types, too:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These macros improve performance and provide more convenient syntax.
 # Features
 
 ## `@with`
-. 
+
 `@with` allows DataFrame columns to be referenced as symbols like
 `:colX` in expressions. If an expression is wrapped in `^(expr)`,
 `expr` gets passed through untouched. If an expression is wrapped in

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These macros improve performance and provide more convenient syntax.
 # Features
 
 ## `@with`
-
+. 
 `@with` allows DataFrame columns to be referenced as symbols like
 `:colX` in expressions. If an expression is wrapped in `^(expr)`,
 `expr` gets passed through untouched. If an expression is wrapped in

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -32,7 +32,7 @@ replace_syms!(e::Expr, membernames) =
     if onearg(e, :^)
         e.args[2]
     elseif onearg(e, :_I_)
-        warn("_I_() for escaping variables is deprecated, use cols() instead")
+        @warn "_I_() for escaping variables is deprecated, use cols() instead"
         addkey!(membernames, :($(e.args[2])))     
     elseif onearg(e, :cols)
         addkey!(membernames, :($(e.args[2])))

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -31,6 +31,9 @@ replace_syms!(q::QuoteNode, membernames) =
 replace_syms!(e::Expr, membernames) =
     if onearg(e, :^)
         e.args[2]
+    elseif onearg(e, :_I_)
+        warn("_I_() for escaping variables is deprecated, use cols() instead")
+        addkey!(membernames, :($(e.args[2])))     
     elseif onearg(e, :cols)
         addkey!(membernames, :($(e.args[2])))
     elseif e.head == :quote

--- a/src/DataFramesMeta.jl
+++ b/src/DataFramesMeta.jl
@@ -31,7 +31,7 @@ replace_syms!(q::QuoteNode, membernames) =
 replace_syms!(e::Expr, membernames) =
     if onearg(e, :^)
         e.args[2]
-    elseif onearg(e, :_I_)
+    elseif onearg(e, :cols)
         addkey!(membernames, :($(e.args[2])))
     elseif e.head == :quote
         addkey!(membernames, Meta.quot(e.args[1]) )
@@ -113,7 +113,7 @@ tempfun(d[:a], d[:b])
 All of the other DataFramesMeta macros are based on `@with`.
 
 If an expression is wrapped in `^(expr)`, `expr` gets passed through untouched.
-If an expression is wrapped in  `_I_(expr)`, the column is referenced by the
+If an expression is wrapped in  `cols(expr)`, the column is referenced by the
 variable `expr` rather than a symbol.
 
 ### Examples
@@ -160,8 +160,7 @@ julia> @with(df, df[:x .> 1, ^(:y)]) # The ^ means leave the :y alone
 
 julia> colref = :x;
 
-julia> @with(df, :y + _I_(colref)) # Equivalent to df[:y] + df[colref]
-3-element Array{Int64,1}:
+julia> @with(df, :y + cols(colref)) # Equivalent to df[:y] + df[colref]
  3
  3
  5

--- a/test/dataframes.jl
+++ b/test/dataframes.jl
@@ -21,9 +21,9 @@ x = @with df begin
     res
 end
 idx = :A
-@test  @with(df, _I_(idx) .+ :B)  ==  df[:A] .+ df[:B]
+@test  @with(df, cols(idx) .+ :B)  ==  df[:A] .+ df[:B]
 idx2 = :B
-@test  @with(df, _I_(idx) .+ _I_(idx2))  ==  df[:A] .+ df[:B]
+@test  @with(df, cols(idx) .+ cols(idx2))  ==  df[:A] .+ df[:B]
 
 @test  x == sum(df[:A] .* df[:B])
 @test  @with(df, df[:A .> 1, ^([:B, :A])]) == df[df[:A] .> 1, [:B, :A]]


### PR DESCRIPTION
`_I_` is a necessary and useful function in DataFramesMeta, but it is ugly to look at and difficult to read. 

This PR did a find and replace for `_I_` to `cols` across all files. 

Both `JuliaDBMeta` and `StatPlots` have the same escaping features, and both call their function `cols`. This PR makes `DataFramesMeta` more consistent with the rest of the ecosystem. 